### PR TITLE
Accela python client

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,4 @@ List of Accela Github Resources. Pull Requests are Welcome!
 ## Libraries:
 * [michaelachrisco/accelapy](https://github.com/michaelachrisco/accelapy) - Accela Python Client Library
 * [axtheset/accela-ruby](https://github.com/axtheset/accela-ruby) - Accela Ruby Client Library
+* [atwalsh/accela](https://github.com/atwalsh/accela) - Lightweight Python client for the Accela API.


### PR DESCRIPTION
Add in https://github.com/atwalsh/accela from @atwalsh

Looks very similar to the `accelapy` package except a bit more light weight. Looks solid. 